### PR TITLE
fix(reads): correct Amazon URL for Burnout Society book

### DIFF
--- a/src/pages/reads/index.astro
+++ b/src/pages/reads/index.astro
@@ -18,7 +18,7 @@ const reads: Reads[] = [
     items: [
       {
         title: "The Burnout Society",
-        url: "https://www.amazon.com/Burnout-Society-Byung-Chul-Han/dp/0804795096e",
+        url: "https://www.amazon.com/Burnout-Society-Byung-Chul-Han/dp/0804795096",
         type: ["book", "non-tech"],
       },
       {


### PR DESCRIPTION
- Remove erroneous 'e' character from the end of Amazon book URL