### PR TITLE
feat(reads): add article about Zig and Rust comparison

### DIFF
--- a/src/pages/reads/index.astro
+++ b/src/pages/reads/index.astro
@@ -80,6 +80,11 @@ const reads: Reads[] = [
             url: "https://slatestarcodex.com/2017/12/28/adderall-risks-much-more-than-you-wanted-to-know/",
             type: ["article", "non-tech"],
           },
+          {
+            title: "How I think about Zig and Rust",
+            url: "https://lewiscampbell.tech/blog/250117.html",
+            type: ["article", "tech"],
+          },
         ],
       },
     ],


### PR DESCRIPTION
Add Lewis Campbell's article discussing thoughts on Zig and Rust programming languages to the January 2025 reading list.